### PR TITLE
Updated jsonwebtoken to version 5.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   },
   "homepage": "https://github.com/ghaiklor/sails-service-cipher#readme",
   "dependencies": {
-    "jsonwebtoken": "5.0.5",
+    "jsonwebtoken": "5.1.0",
     "lodash": "3.10.1"
   },
   "devDependencies": {


### PR DESCRIPTION
:rocket:

jsonwebtoken just published version 5.1.0, so that’s now up to date in your `package.json`.

Check that it doesn’t break your code and release the new version of your software safe in the knowledge that it will stay in this working state.

---
The new version differs by 3 commits (ahead by 3, behind by 0).

- [83d7aff](https://github.com/auth0/node-jsonwebtoken/commit/83d7aff9fb317aadb5bed073a6b0663220f14c7d): 5.1.0
- [1fa326f](https://github.com/auth0/node-jsonwebtoken/commit/1fa326fcd1368034a7105f2a81d0c0d916a2eef5): Merge pull request #127 from lukewestby/master
- [9414fbc](https://github.com/auth0/node-jsonwebtoken/commit/9414fbcb15a1f9cf4fe147d070e9424c547dabba): added async signing

See the [full diff](https://github.com/auth0/node-jsonwebtoken/compare/6a715a13992c888db77cc5b274e5fd28633e4c76...83d7aff9fb317aadb5bed073a6b0663220f14c7d).

---
This pull request was created by [greenkeeper.io](http://greenkeeper.io/).
It keeps your software, up to date, all the time.

<sub>
Tired of seeing this sponsor message? Upgrade to the supporter plan!
You'll also get your pull requests faster :zap:
</sub>